### PR TITLE
Minor README and script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This repository will eventually contain:
 
 * Scripts and code for setting up and running Tendermint-based networks using
   various deployment mechanisms and configuration management schemes.
-* Test network experiments
+* [Test network experiments](testing/README.md)
   - Configuration scripts
   - Experimental test results

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,7 +1,8 @@
 GOPATH?=$(shell go env GOPATH)
 # NOTE: INVENTORY variable *must* be absolute path
-INVENTORY?=$(GOPATH)/src/github.com/tendermint/tendermint/test/remote/inventory/hosts
+INVENTORY?=inventory/hosts
 LOGS_DIR?=/tmp
+.PHONY: distribute-pubkey distribute-known_hosts
 
 include common/make/python-ansible.mk
 
@@ -30,3 +31,19 @@ scenario\:%: venv/bin/ansible
 plot-results\:%: venv
 	@$(ACTIVATE_VENV); \
 	$(MAKE) -C scenarios/$*/ plot-results
+
+PUBLIC_KEY_PATH?=/tmp/pubkey.pub
+PUBLIC_KEY_STATE?=present
+distribute-pubkey:
+	@$(ACTIVATE_VENV); \
+	ansible-playbook -i $(INVENTORY) \
+		-e "{\"public_key_path\": \"${PUBLIC_KEY_PATH}\"}" \
+		-e "{\"public_key_state\": \"${PUBLIC_KEY_STATE}\"}" \
+		utils/distribute-pubkey.yml
+
+KNOWN_HOSTS_PATH?=/tmp/known_hosts
+distribute-known_hosts:
+	@$(ACTIVATE_VENV); \
+	ansible-playbook -i $(INVENTORY) \
+		-e "{\"known_hosts_path\": \"${KNOWN_HOSTS_PATH}\"}" \
+		utils/distribute-known_hosts.yml

--- a/testing/experiments/v0.28.0/002-no-empty-blocks-issue-steady-increase/README.md
+++ b/testing/experiments/v0.28.0/002-no-empty-blocks-issue-steady-increase/README.md
@@ -7,6 +7,8 @@ This folder contains experimental results using the following parameters.
 | Tendermint version | v0.28.0 |
 | Proxy app | `kvstore` |
 | Network configuration | `002-no-empty-blocks-issue` |
+| Tendermint nodes | 4 |
+| Load test nodes | 4 |
 | Protocol | HTTP |
 | RPCs used | `broadcast_tx_sync`, `abci_query` |
 | Starting clients | 100 |

--- a/testing/experiments/v0.28.0/002-no-empty-blocks-issue/README.md
+++ b/testing/experiments/v0.28.0/002-no-empty-blocks-issue/README.md
@@ -7,6 +7,8 @@ This folder contains experimental results using the following parameters.
 | Tendermint version | v0.28.0 |
 | Proxy app | `kvstore` |
 | Network configuration | `002-no-empty-blocks-issue` |
+| Tendermint nodes | 4 |
+| Load test nodes | 4 |
 | Protocol | HTTP |
 | RPCs used | `broadcast_tx_sync`, `abci_query` |
 | Starting clients | 100 |

--- a/testing/experiments/v0.29.1/002-no-empty-blocks-issue/README.md
+++ b/testing/experiments/v0.29.1/002-no-empty-blocks-issue/README.md
@@ -7,6 +7,8 @@ This folder contains experimental results using the following parameters.
 | Tendermint version | v0.29.1 |
 | Proxy app | `kvstore` |
 | Network configuration | `002-no-empty-blocks-issue` |
+| Tendermint nodes | 4 |
+| Load test nodes | 4 |
 | Protocol | HTTP |
 | RPCs used | `broadcast_tx_sync`, `abci_query` |
 | Starting clients | 100 |

--- a/testing/networks/001-reference/update-node-config.sh
+++ b/testing/networks/001-reference/update-node-config.sh
@@ -5,7 +5,7 @@ NODE_DOMAIN=${NODE_DOMAIN:-"sredev.co"}
 
 for CFG_FILE in $(find /tmp/nodes -name 'config.toml'); do
     NODE_ID=$(basename $(dirname $(dirname ${CFG_FILE})))
-    sed -i '' \
+    sed -i'' \
         -e "s/t\([ioa]\)k\([0-9]*\):/t\1k\2.${NODE_DOMAIN}:/g" \
         -e "s/^proxy_app = \(.*\)$/proxy_app = \"kvstore\"/" \
         -e "s/^moniker = \(.*\)$/moniker = \"${NODE_ID}\"/" \

--- a/testing/networks/002-no-empty-blocks-issue/update-node-config.sh
+++ b/testing/networks/002-no-empty-blocks-issue/update-node-config.sh
@@ -5,7 +5,7 @@ NODE_DOMAIN=${NODE_DOMAIN:-"sredev.co"}
 
 for CFG_FILE in $(find /tmp/nodes -name 'config.toml'); do
     NODE_ID=$(basename $(dirname $(dirname ${CFG_FILE})))
-    sed -i '' \
+    sed -i'' \
         -e "s/t\([ioa]\)k\([0-9]*\):/t\1k\2.${NODE_DOMAIN}:/g" \
         -e "s/^proxy_app = \(.*\)$/proxy_app = \"kvstore\"/" \
         -e "s/^moniker = \(.*\)$/moniker = \"${NODE_ID}\"/" \

--- a/testing/scenarios/003-kvstore-loadtest-distributed/locust_file_http.py
+++ b/testing/scenarios/003-kvstore-loadtest-distributed/locust_file_http.py
@@ -14,6 +14,9 @@ MIN_WAIT = int(os.environ.get('MIN_WAIT', 100))
 MAX_WAIT = int(os.environ.get('MAX_WAIT', 500))
 
 
+# TODO: Build a better HTTP client here with better error handling.
+
+
 class KVStoreBalancedRWTaskSequence(TaskSequence):
     """A balanced read/write task set for interacting with the nodes."""
 

--- a/testing/scenarios/003-kvstore-loadtest-distributed/locust_file_websockets.py
+++ b/testing/scenarios/003-kvstore-loadtest-distributed/locust_file_websockets.py
@@ -53,6 +53,8 @@ class WebSocketsKVStoreClient(object):
                 if result_value_decoded != expected:
                     events.request_failure.fire(request_type='ws', name=rpc_obj['method'], response_time=total_time, exception=Exception("Response value mismatch"))
                     return result
+            elif result_value is not None:
+                events.request_failure.fire(request_type="ws", name=rpc_obj['method'], response_time=total_time, exception=Exception("Unexpected response format from server"))
             events.request_success.fire(request_type="ws", name=rpc_obj['method'], response_time=total_time, response_length=len(result))
         return result
 

--- a/testing/utils/distribute-known_hosts.yml
+++ b/testing/utils/distribute-known_hosts.yml
@@ -1,0 +1,19 @@
+---
+- hosts: "{{ lookup('env', 'TARGET_HOSTS').split(',') }}"
+  vars:
+    known_hosts_user: centos
+    known_hosts_path: /tmp/known_hosts
+  tasks:
+    - name: Check if the known_hosts file exists
+      stat: "path=/home/{{ known_hosts_user }}/.ssh/known_hosts"
+      register: known_hosts
+    - name: Make a backup of the known_hosts file
+      copy:
+        src: "/home/{{ known_hosts_user }}/.ssh/known_hosts"
+        dest: "/home/{{ known_hosts_user }}/.ssh/known_hosts.bak"
+        remote_src: yes
+      when: known_hosts.stat.exists
+    - name: Distribute known_hosts
+      copy:
+        src: "{{ known_hosts_path }}"
+        dest: "/home/{{ known_hosts_user }}/.ssh/known_hosts"

--- a/testing/utils/distribute-pubkey.yml
+++ b/testing/utils/distribute-pubkey.yml
@@ -1,0 +1,21 @@
+---
+- hosts: "{{ lookup('env', 'TARGET_HOSTS').split(',') }}"
+  vars:
+    public_key_user: centos
+    public_key_path: /tmp/pubkey.pub
+    public_key_state: present
+  tasks:
+    - name: Check if the authorized_keys file exists
+      stat: "path=/home/{{ public_key_user }}/.ssh/authorized_keys"
+      register: authorized_keys
+    - name: Make a backup of the authorized_keys file
+      copy:
+        src: "/home/{{ public_key_user }}/.ssh/authorized_keys"
+        dest: "/home/{{ public_key_user }}/.ssh/authorized_keys.bak"
+        remote_src: yes
+      when: authorized_keys.stat.exists
+    - name: Distribute public key
+      authorized_key:
+        user: centos
+        state: "{{ public_key_state }}"
+        key: "{{ lookup('file', public_key_path) }}"


### PR DESCRIPTION
This PR:

* Updates the READMEs for the repo and some of the experiments
* Adds commands to the primary testing `Makefile` to distribute public keys and `known_hosts` files for easier access to test nodes
* Provides minor fixes for the load testing script, which will fail on some versions of Linux due to an incorrect `sed` parameter