### PR TITLE
Fix broken sed command execution (cross-platform)

### DIFF
--- a/testing/networks/001-reference/update-node-config.sh
+++ b/testing/networks/001-reference/update-node-config.sh
@@ -5,7 +5,7 @@ NODE_DOMAIN=${NODE_DOMAIN:-"sredev.co"}
 
 for CFG_FILE in $(find /tmp/nodes -name 'config.toml'); do
     NODE_ID=$(basename $(dirname $(dirname ${CFG_FILE})))
-    sed -i'' \
+    sed -i.orig \
         -e "s/t\([ioa]\)k\([0-9]*\):/t\1k\2.${NODE_DOMAIN}:/g" \
         -e "s/^proxy_app = \(.*\)$/proxy_app = \"kvstore\"/" \
         -e "s/^moniker = \(.*\)$/moniker = \"${NODE_ID}\"/" \

--- a/testing/networks/002-no-empty-blocks-issue/update-node-config.sh
+++ b/testing/networks/002-no-empty-blocks-issue/update-node-config.sh
@@ -5,7 +5,7 @@ NODE_DOMAIN=${NODE_DOMAIN:-"sredev.co"}
 
 for CFG_FILE in $(find /tmp/nodes -name 'config.toml'); do
     NODE_ID=$(basename $(dirname $(dirname ${CFG_FILE})))
-    sed -i'' \
+    sed -i.orig \
         -e "s/t\([ioa]\)k\([0-9]*\):/t\1k\2.${NODE_DOMAIN}:/g" \
         -e "s/^proxy_app = \(.*\)$/proxy_app = \"kvstore\"/" \
         -e "s/^moniker = \(.*\)$/moniker = \"${NODE_ID}\"/" \


### PR DESCRIPTION
The currently employed `sed` command doesn't work across both macOS and Linux (the `-i` parameter, specifically). This fixes that.