### PR TITLE
Add script to remove Toxiproxy from all servers

### DIFF
--- a/testing/utils/remove-toxiproxy.yml
+++ b/testing/utils/remove-toxiproxy.yml
@@ -1,0 +1,21 @@
+---
+- hosts:
+    - tik
+    - tak
+    - tok
+  become: yes
+  tasks:
+    - name: Check if Toxiproxy service exists
+      stat: path=/etc/systemd/system/toxiproxy.service
+      register: tp_service
+    - name: Stop Toxiproxy if present
+      service: name=toxiproxy state=stopped enabled=no
+      when: tp_service.stat.exists
+    - name: Delete service and executables
+      file: "path={{ item }} state=absent"
+      with_items:
+        - /etc/systemd/system/toxiproxy.service
+        - /usr/bin/toxiproxy-server
+        - /usr/bin/toxiproxy-cli
+    - name: Reload systemd services
+      systemd: daemon_reload=yes


### PR DESCRIPTION
Toxiproxy is no longer a feasible option in terms of simulation network outages - the configuration complexity grows along with the number of nodes due to the fact that the P2P connections between Tendermint nodes could be bidirectional.