### PR TITLE
Add utils to get and distribute internal host IPs

### DIFF
--- a/testing/utils/distribute-hosts.yml
+++ b/testing/utils/distribute-hosts.yml
@@ -1,0 +1,20 @@
+---
+# Utility script to distribute a "hosts" file to a list of target hosts
+- hosts:
+    - tik
+    - tak
+    - tok
+  become: yes
+  gather_facts: no
+  vars:
+    hosts_file: /tmp/hosts
+  tasks:
+    - name: Copy hosts file across
+      copy: "src={{ hosts_file }} dest=/tmp/hosts"
+    - name: Add/update hosts entries in /etc/hosts
+      shell: |
+        cp /etc/hosts /etc/hosts.bak
+        while IFS="" read -r line || [ -n "$line" ]; do
+          ipaddr=`echo ${line} | sed "s/\([0-9.]*\).*/\1/"`
+          printf "`grep -v ${ipaddr} /etc/hosts`\n${line}\n" > /etc/hosts
+        done < /tmp/hosts

--- a/testing/utils/get-internal-ips.yml
+++ b/testing/utils/get-internal-ips.yml
@@ -1,0 +1,17 @@
+---
+# Ansible playbook utility script to fetch servers' internal IP addresses
+- hosts:
+    - tik
+    - tak
+    - tok
+  become: yes
+  gather_facts: no
+  tasks:
+    - name: Run ifconfig on remote host
+      shell: |
+        ifconfig eth0 > /tmp/ifconfig.log 2>&1
+    - name: Fetch ifconfig output files for each host
+      fetch:
+        src: /tmp/ifconfig.log
+        dest: "/tmp/ifconfig-{{ inventory_hostname }}"
+        flat: yes

--- a/testing/utils/ifconfig-to-hosts.sh
+++ b/testing/utils/ifconfig-to-hosts.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+for FILENAME in $(find /tmp/ -name 'ifconfig-*' | sort); do
+    HOST=`echo ${FILENAME} | sed -e "s/.*ifconfig-\(.*\)/\1/"`
+    IP_ADDR=`cat ${FILENAME} | grep 'inet ' | sed -e "s/.*inet \([0-9.]*\).*/\1/"`
+    echo "${IP_ADDR}\t${HOST}"
+done

--- a/testing/utils/restore-hosts.yml
+++ b/testing/utils/restore-hosts.yml
@@ -1,0 +1,12 @@
+---
+# Utility script to restore /etc/hosts.bak to /etc/hosts
+- hosts:
+    - tik
+    - tak
+    - tok
+  become: yes
+  gather_facts: no
+  tasks:
+    - name: Restore backup hosts file
+      shell: |
+        cp /etc/hosts.bak /etc/hosts


### PR DESCRIPTION
These utilities assist with fetching the internal IP addresses of the targeted hosts, copying them to the local machine, combines them into a single "hosts" file, and then distributes these by inserting/updating the relevant entries on all targeted hosts' machines.