### PR TITLE
Add outage simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /testing/venv/
 /testing/experiments/**/*-clients-*/
 /testing/experiments/**/collection.log
+/testing/common/apps/outage-sim-server/outage-sim-server
 *.pyc
 __pycache__
 *.bak

--- a/testing/common/ansible/config/outage-sim-server.service
+++ b/testing/common/ansible/config/outage-sim-server.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Tendermint Outage Simulator Server
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+User=root
+Group=root
+PermissionsStartOnly=true
+ExecStart=/usr/bin/outage-sim-server
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=outage-sim-server
+
+[Install]
+WantedBy=multi-user.target

--- a/testing/common/ansible/install-outage-sim-svc.yml
+++ b/testing/common/ansible/install-outage-sim-svc.yml
@@ -1,0 +1,17 @@
+# -------------------------------------------
+# Installs Tendermint outage simulator server
+# -------------------------------------------
+- name: Copy binary to nodes
+  copy:
+    src: ../apps/outage-sim-server/outage-sim-server
+    dest: /usr/bin/outage-sim-server
+    owner: root
+    group: root
+    mode: 0755
+- name: Copy service definition to nodes
+  copy:
+    src: config/outage-sim-server.service
+    dest: /etc/systemd/system/outage-sim-server.service
+- name: Reload systemd services
+  systemd:
+    daemon_reload: yes

--- a/testing/common/apps/outage-sim-server/outage_sim_server.go
+++ b/testing/common/apps/outage-sim-server/outage_sim_server.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os/exec"
+)
+
+func isTendermintRunning() bool {
+	cmd := exec.Command("pidof", "tendermint")
+	return cmd.Run() == nil
+}
+
+func executeServiceCmd(status string) error {
+	cmd := exec.Command("service", "tendermint", status)
+	return cmd.Run()
+}
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			if r.Body != nil {
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					fmt.Fprint(w, "Internal server error while reading request body")
+				}
+				switch string(body) {
+				case "up":
+					if !isTendermintRunning() {
+						if err := executeServiceCmd("start"); err != nil {
+							w.WriteHeader(http.StatusInternalServerError)
+							fmt.Fprint(w, "Failed to start Tendermint process")
+						} else {
+							w.WriteHeader(http.StatusOK)
+							fmt.Fprint(w, "Service successfully started")
+						}
+					} else {
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, "Service is already running")
+					}
+				case "down":
+					if isTendermintRunning() {
+						if err := executeServiceCmd("stop"); err != nil {
+							w.WriteHeader(http.StatusInternalServerError)
+							fmt.Fprint(w, "Failed to stop Tendermint process")
+						} else {
+							w.WriteHeader(http.StatusOK)
+							fmt.Fprint(w, "Service successfully stopped")
+						}
+					} else {
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprint(w, "Service is already stopped")
+					}
+				default:
+					w.WriteHeader(http.StatusBadRequest)
+					fmt.Fprint(w, "Unrecognised command")
+				}
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, "Missing command in request")
+			}
+		} else {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			fmt.Fprintf(w, "Unsupported method: %s", r.Method)
+		}
+	})
+	log.Fatal(http.ListenAndServe(":34000", nil))
+}

--- a/testing/networks/001-reference/Makefile
+++ b/testing/networks/001-reference/Makefile
@@ -5,7 +5,7 @@ FAST_MODE?=false
 
 include ../../common/make/tendermint.mk
 
-deploy: $(TMBIN)
+deploy: $(TMBIN) ../../common/apps/outage-sim-server/outage-sim-server
 	rm -rf /tmp/nodes/
 	tendermint testnet \
 		--v 4 \
@@ -24,3 +24,9 @@ fetch-tm-logs:
 
 status:
 	@SLEEP=0 ./check-status.sh
+
+# Builds our outage simulator server for Linux
+../../common/apps/outage-sim-server/outage-sim-server:
+	GOOS=linux GOARCH=amd64 go build \
+		-o ../../common/apps/outage-sim-server/outage-sim-server \
+		../../common/apps/outage-sim-server/outage_sim_server.go

--- a/testing/networks/001-reference/deploy.yml
+++ b/testing/networks/001-reference/deploy.yml
@@ -2,17 +2,18 @@
 - hosts: tik
   become: yes
   vars:
-    always_deploy_svc: no
+    always_deploy_svc: yes
     local_tmbin: "{{ lookup('env', 'GOPATH') }}/src/github.com/tendermint/tendermint/build/tendermint"
     fast_mode: no
   tasks:
-    - name: Check if Toxiproxy service is present
-      stat: path=/etc/systemd/system/toxiproxy.service
-      register: tp_service
-      when: not fast_mode
-    - name: Stop and disable Toxiproxy if present
-      service: name=toxiproxy state=stopped enabled=no
-      when: not fast_mode and tp_service.stat.exists
+    - name: Check if outage simulator server service is present
+      stat: path=/etc/systemd/system/outage-sim-server.service
+      register: outage_sim_server
+    - name: Install outage simulator service if not present
+      include_tasks: ../../common/ansible/install-outage-sim-svc.yml
+      when: not fast_mode and (always_deploy_svc or not outage_sim_server.stat.exists)
+    - name: Ensure outage simulator is up and ready
+      service: name=outage-sim-server state=restarted
 
     # Check if we need to configure the systemd service
     - name: Check if Tendermint service is present

--- a/testing/networks/001-reference/deploy.yml
+++ b/testing/networks/001-reference/deploy.yml
@@ -2,7 +2,7 @@
 - hosts: tik
   become: yes
   vars:
-    always_deploy_svc: yes
+    always_deploy_svc: no
     local_tmbin: "{{ lookup('env', 'GOPATH') }}/src/github.com/tendermint/tendermint/build/tendermint"
     fast_mode: no
   tasks:

--- a/testing/networks/002-no-empty-blocks-issue/Makefile
+++ b/testing/networks/002-no-empty-blocks-issue/Makefile
@@ -5,7 +5,7 @@ FAST_MODE?=false
 
 include ../../common/make/tendermint.mk
 
-deploy: $(TMBIN)
+deploy: $(TMBIN) ../../common/apps/outage-sim-server/outage-sim-server
 	rm -rf /tmp/nodes/
 	tendermint testnet \
 		--v 4 \
@@ -24,3 +24,10 @@ fetch-tm-logs:
 
 status:
 	@SLEEP=0 ./check-status.sh
+
+# Builds our outage simulator server for Linux
+../../common/apps/outage-sim-server/outage-sim-server:
+	GOOS=linux GOARCH=amd64 go build \
+		-o ../../common/apps/outage-sim-server/outage-sim-server \
+		../../common/apps/outage-sim-server/outage_sim_server.go
+

--- a/testing/networks/002-no-empty-blocks-issue/deploy.yml
+++ b/testing/networks/002-no-empty-blocks-issue/deploy.yml
@@ -7,13 +7,14 @@
     delete_logs: yes
     fast_mode: no
   tasks:
-    - name: Check if Toxiproxy service is present
-      stat: path=/etc/systemd/system/toxiproxy.service
-      register: tp_service
-      when: not fast_mode
-    - name: Stop and disable Toxiproxy if present
-      service: name=toxiproxy state=stopped enabled=no
-      when: not fast_mode and tp_service.stat.exists
+    - name: Check if outage simulator server service is present
+      stat: path=/etc/systemd/system/outage-sim-server.service
+      register: outage_sim_server
+    - name: Install outage simulator service if not present
+      include_tasks: ../../common/ansible/install-outage-sim-svc.yml
+      when: not fast_mode and (always_deploy_svc or not outage_sim_server.stat.exists)
+    - name: Ensure outage simulator is up and ready
+      service: name=outage-sim-server state=restarted
 
     # Check if we need to configure the systemd service
     - name: Check if Tendermint service is present

--- a/testing/scenarios/003-kvstore-loadtest-distributed/Makefile
+++ b/testing/scenarios/003-kvstore-loadtest-distributed/Makefile
@@ -19,6 +19,7 @@ execute:
 		-e "{\"run_timeout\":${RUN_TIMEOUT}}" \
 		-e "{\"fast_mode\":${FAST_MODE}}" \
 		-e "{\"results_output_dir\":\"${RESULTS_OUTPUT_DIR}\"}" \
+		-e "{\"outage_sim\":\"${OUTAGE_SIM}\"}" \
 		deploy.yml
 
 # Command to help to just fetch the logs again

--- a/testing/scenarios/003-kvstore-loadtest-distributed/deploy.yml
+++ b/testing/scenarios/003-kvstore-loadtest-distributed/deploy.yml
@@ -33,6 +33,9 @@
     run_timeout: 330 # In seconds - must be longer than run_time.
     log_file: "{{ loadtest_home }}/loadtest.log"
     stdout_file: "{{ loadtest_home }}/loadtest.stdout.log"
+
+    # Outage simulation
+    outage_sim: ""
   tasks:
     - name: Check if Tendermint service is present
       stat: "path=/etc/systemd/system/tendermint.service"
@@ -57,6 +60,7 @@
         - "locust_file_http.py"
         - "locust_file_websockets.py"
         - "execute_load_test.sh"
+        - "outage_sim_client.py"
       when: (not fast_mode)
     - name: Configure the permissions for the loadtest user home folder
       file:
@@ -64,10 +68,13 @@
         owner: "{{ loadtest_user }}"
         group: "{{ loadtest_group }}"
       when: (not fast_mode)
-    - name: Configure executable permissions for load test execution script
+    - name: Configure executable permissions for scripts
       file:
-        path: "{{ loadtest_home }}/execute_load_test.sh"
+        path: "{{ loadtest_home }}/{{ item }}"
         mode: 0755
+      with_items:
+        - execute_load_test.sh
+        - outage_sim_client.py
       when: (not fast_mode)
     - name: Clear out existing log/statistics files, if they exist
       file:
@@ -93,6 +100,7 @@
           EXPECTED_SLAVE_COUNT={{ expected_slave_count }} \
           LOADTEST_MASTER_NODE={{ loadtest_master_node }} \
           LOADTEST_MASTER_HOSTNAME={{ loadtest_master_hostname }} \
+          OUTAGE_SIM="{{ outage_sim }}" \
           ./execute_load_test.sh
       args:
         chdir: "{{ loadtest_home }}"

--- a/testing/scenarios/003-kvstore-loadtest-distributed/execute_load_test.sh
+++ b/testing/scenarios/003-kvstore-loadtest-distributed/execute_load_test.sh
@@ -24,7 +24,7 @@ source venv/bin/activate
 if [ "${INVENTORY_HOSTNAME}" == "${LOADTEST_MASTER_NODE}" ]; then
     # We want to run the outage simulator script from the master node
     if [[ $OUTAGE_SIM ]]; then
-        ./outage-sim-client.py > ${OUTAGE_SIM_LOG} 2>&1 &
+        ./outage_sim_client.py > ${OUTAGE_SIM_LOG} 2>&1 &
         OUTAGE_SIM_PID=$!
     fi
 

--- a/testing/scenarios/003-kvstore-loadtest-distributed/execute_load_test.sh
+++ b/testing/scenarios/003-kvstore-loadtest-distributed/execute_load_test.sh
@@ -12,6 +12,9 @@ LOG_FILE=${LOG_FILE:-"./loadtest.log"}
 STDOUT_FILE=${STDOUT_FILE:-"loadtest.stdout.log"}
 LOADTEST_MASTER_NODE=${LOADTEST_MASTER_NODE:-"tok0"}
 LOADTEST_MASTER_HOSTNAME=${LOADTEST_MASTER_HOSTNAME:-"tok0.sredev.co"}
+OUTAGE_SIM=${OUTAGE_SIM:-""}
+OUTAGE_SIM_LOG=${OUTAGE_SIM_LOG:-"outage-sim.log"}
+OUTAGE_SIM_PID=0
 
 # Parameters common to both master and slaves
 LOCUST_PARAMS="--csv ${CSV_OUTPUT_FILE} -c ${NUM_CLIENTS} -r ${HATCH_RATE} --logfile ${LOG_FILE}"
@@ -19,6 +22,12 @@ LOCUST_PARAMS="--csv ${CSV_OUTPUT_FILE} -c ${NUM_CLIENTS} -r ${HATCH_RATE} --log
 source venv/bin/activate
 
 if [ "${INVENTORY_HOSTNAME}" == "${LOADTEST_MASTER_NODE}" ]; then
+    # We want to run the outage simulator script from the master node
+    if [[ $OUTAGE_SIM ]]; then
+        ./outage-sim-client.py > ${OUTAGE_SIM_LOG} 2>&1 &
+        OUTAGE_SIM_PID=$!
+    fi
+
     HOST_URLS=${TARGET_HOSTS} \
         locust -f locust_file_${TARGET_HOSTS_PROTO}.py \
         --no-web \
@@ -28,6 +37,12 @@ if [ "${INVENTORY_HOSTNAME}" == "${LOADTEST_MASTER_NODE}" ]; then
         --expect-slaves ${EXPECTED_SLAVE_COUNT} \
         -t ${RUN_TIME} \
         ${LOCUST_PARAMS} > ${STDOUT_FILE} 2>&1
+
+    if [[ $OUTAGE_SIM ]]; then
+        if ps -p ${OUTAGE_SIM_PID} > /dev/null; then
+            kill ${OUTAGE_SIM_PID}
+        fi
+    fi
 else
     HOST_URLS=${TARGET_HOSTS} \
         locust -f locust_file_${TARGET_HOSTS_PROTO}.py \

--- a/testing/scenarios/003-kvstore-loadtest-distributed/outage_sim_client.py
+++ b/testing/scenarios/003-kvstore-loadtest-distributed/outage_sim_client.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import requests
+
+
+OUTAGE_SIM = os.environ.get('OUTAGE_SIM', '')
+
+
+class SimulationInstruction:
+    def __init__(self, host, cmd):
+        self.host = host
+        self.cmd = cmd
+    
+    def execute(self):
+        print("Bringing %s %s" % (self.host, self.cmd))
+        r = requests.post('http://%s:34000', data=self.cmd)
+        if r.status_code >= 400:
+            print("FAILED: Response code %d" % r.status_code)
+        else:
+            print("Success!")
+        print("")
+    
+    def __repr__(self):
+        return "SimulationInstruction(host=%s, cmd=%s)" % (self.host, self.cmd)
+
+
+class SimulationStep:
+    def __init__(self, wait_period, instructions):
+        self.wait_period = wait_period
+        # we only want relevant instructions
+        self.instructions = instructions
+    
+    def execute(self):
+        if self.wait_period > 0:
+            print("Waiting %d second(s)..." % self.wait_period)
+            time.sleep(self.wait_period)
+
+        for i in self.instructions:
+            i.execute()
+    
+    def __repr__(self):
+        return "SimulationStep(wait_period=%d, instructions=%s)" % (self.wait_period, self.instructions)
+
+
+def extract_sim_plan():
+    """Extracts the outage simulation plan from the OUTAGE_SIMULATION variable.
+    
+    The OUTAGE_SIMULATION structure looks as follows:
+
+        60:tik0=up,tik1=down|360:tik0=down|60:tik0=up,tik1=up
+    
+    The above simulation will:
+        1. Wait 60 seconds, then ensure tik0 is up and tik1 is down
+        2. Then, wait 360 seconds, and ensure tik0 is down
+        3. Then, wait 60 more seconds and ensure tik0 and tik1 are both up
+    """
+    plan = []
+    steps = OUTAGE_SIM.split("|")
+    for step in steps:
+        s_parts = step.split(":")
+        if len(s_parts) == 2:
+            wait_period, instructions = int(s_parts[0]), s_parts[1].split(',')
+            _instructions = []
+            for i in instructions:
+                i_parts = i.split('=')
+                if len(i_parts) == 2:
+                    _instructions.append(SimulationInstruction(i_parts[0], i_parts[1]))
+            plan.append(SimulationStep(wait_period, _instructions))
+    
+    return plan
+
+
+def main():
+    sim_plan = extract_sim_plan()
+    print("Built simulation plan: %d step(s)" % len(sim_plan))
+    for i in range(len(sim_plan)):
+        print("%.3d: %s" % (i, repr(sim_plan[i])))
+    
+    print("")
+
+    for step in sim_plan:
+        step.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/scenarios/003-kvstore-loadtest-distributed/outage_sim_client.py
+++ b/testing/scenarios/003-kvstore-loadtest-distributed/outage_sim_client.py
@@ -16,7 +16,7 @@ class SimulationInstruction:
     
     def execute(self):
         print("Bringing %s %s" % (self.host, self.cmd))
-        r = requests.post('http://%s:34000', data=self.cmd)
+        r = requests.post('http://%s:34000' % self.host, data=self.cmd)
         if r.status_code >= 400:
             print("FAILED: Response code %d" % r.status_code)
         else:

--- a/testing/scenarios/003-kvstore-loadtest-distributed/requirements.txt
+++ b/testing/scenarios/003-kvstore-loadtest-distributed/requirements.txt
@@ -1,2 +1,3 @@
 locustio
 websocket-client
+requests


### PR DESCRIPTION
We need a way to simulate outages of specific nodes, and Toxiproxy or the like just won't cut it (as per #7). This allows us direct control of the `systemd` Tendermint process via HTTP during load testing, where we have:

* A simple Go-based HTTP service that listens on the Tendermint nodes (only accessible on the internal network - not exposed to the public Internet) for commands (`up` or `down`) and either brings up or down the Tendermint service on that node accordingly.
* A simple Python-based outage simulator client, which parses a simulation parameter (`OUTAGE_SIM`) to use as its instructions as to which nodes to bring up/down and when.

The `OUTAGE_SIM` parameter is of the following format:

```
60:tik0=up,tik1=down|360:tik0=down|60:tik0=up,tik1=up
```

The above simulation will:
1. Wait 60 seconds, then ensure tik0 is up and tik1 is down
2. Then, wait 360 seconds, and ensure tik0 is down
3. Then, wait 60 more seconds and ensure tik0 and tik1 are both up