### PR TITLE
Set mempool and cache size both to 0

### DIFF
--- a/testing/networks/003-no-mempool/update-node-config.sh
+++ b/testing/networks/003-no-mempool/update-node-config.sh
@@ -12,6 +12,8 @@ for CFG_FILE in $(find /tmp/nodes -name 'config.toml'); do
         -e "s/^log_format = \(.*\)$/log_format = \"json\"/" \
         -e "s/^recheck = \(.*\)$/recheck = false/" \
         -e "s/^broadcast = \(.*\)$/broadcast = false/" \
+        -e "s/^size = 5000$/size = 0/" \
+        -e "s/^cache_size = 10000$/cache_size = 0/" \
         -e "s/^create_empty_blocks = \(.*\)$/create_empty_blocks = false/" \
         -e "s/^prometheus = \(.*\)$/prometheus = true/" \
         ${CFG_FILE}


### PR DESCRIPTION
Fixes error in previous configuration update to ensure that the mempool and cache sizes are both set to 0.