### PR TITLE
Fix/simplify load testing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOBIN?=$(GOPATH)/bin
 SRC_DIR?=$(GOPATH)/src/github.com/tendermint/networks
 BUILD_DIR?=$(SRC_DIR)/build
 .PHONY: build-tm-outage-sim-server build-tm-outage-sim-server-linux \
-	build build-linux \
+	tools tools-linux \
 	clean test lint \
 	get-deps \
 	protos
@@ -37,9 +37,9 @@ build-tm-load-test-linux: get-deps
 		go build -o $(BUILD_DIR)/tm-load-test \
 		$(SRC_DIR)/cmd/tm-load-test/main.go
 
-build: build-tm-outage-sim-server build-tm-load-test
+tools: build-tm-outage-sim-server build-tm-load-test
 
-build-linux: build-tm-outage-sim-server-linux build-tm-load-test-linux
+tools-linux: build-tm-outage-sim-server-linux build-tm-load-test-linux
 
 protos:
 	protoc --gogoslick_out=$(SRC_DIR)/pkg/loadtest/messages/ \

--- a/README.md
+++ b/README.md
@@ -10,3 +10,27 @@ The following tools are provided for use during testing of Tendermint networks:
   application for Tendermint networks.
 * [tm-outage-sim-server](./cmd/tm-outage-sim-server/README.md) - A Tendermint
   node outage simulator, for use in CentOS, Debian/Ubuntu environments.
+
+### Requirements
+In order to build and use the tools, you will need:
+
+* Go 1.11.5+
+* `make`
+
+### Building
+To build the tools:
+
+```bash
+> make tools
+```
+
+This will build the binaries for `tm-load-test` and `tm-outage-sim-server` in a
+`build` directory inside this repository.
+
+### Development
+To run the linter and the tests:
+
+```bash
+> make lint
+> make test
+```

--- a/cmd/tm-load-test/main.go
+++ b/cmd/tm-load-test/main.go
@@ -1,63 +1,9 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"os"
-
-	"github.com/sirupsen/logrus"
 	"github.com/tendermint/networks/pkg/loadtest"
 )
 
 func main() {
-	var (
-		isMaster   = flag.Bool("master", false, "start this process in MASTER mode")
-		isSlave    = flag.Bool("slave", false, "start this process in SLAVE mode")
-		configFile = flag.String("c", "load-test.toml", "the path to the configuration file for a load test")
-		isVerbose  = flag.Bool("v", false, "increase logging verbosity to DEBUG level")
-	)
-	flag.Usage = func() {
-		fmt.Println(`Tendermint load testing utility
-
-tm-load-test is a tool for distributed load testing on Tendermint networks,
-assuming that your Tendermint network currently runs the "kvstore" proxy app.
-
-Usage:
-  tm-load-test -c load-test.toml -master   # Run a master
-  tm-load-test -c load-test.toml -slave    # Run a slave
-
-Flags:`)
-		flag.PrintDefaults()
-		fmt.Println("")
-	}
-	flag.Parse()
-
-	if (!*isMaster && !*isSlave) || (*isMaster && *isSlave) {
-		fmt.Println("Either -master or -slave is expected on the command line to explicitly specify which mode to use.")
-		os.Exit(1)
-	}
-
-	if *isVerbose {
-		logrus.SetLevel(logrus.DebugLevel)
-	}
-	logger := logrus.WithField("ctx", "main")
-
-	var err error
-
-	if *isMaster {
-		logger.Infoln("Starting in MASTER mode")
-		err = loadtest.RunMaster(*configFile)
-	} else {
-		logger.Infoln("Starting in SLAVE mode")
-		err = loadtest.RunSlave(*configFile)
-	}
-
-	if err != nil {
-		logger.WithError(err).Errorln("Load test execution failed")
-		if ltErr, ok := err.(*loadtest.Error); ok {
-			os.Exit(int(ltErr.Code))
-		} else {
-			os.Exit(1)
-		}
-	}
+	loadtest.Run()
 }

--- a/pkg/loadtest/README.md
+++ b/pkg/loadtest/README.md
@@ -1,0 +1,49 @@
+# Tendermint Load Testing Framework
+
+By default, `tm-load-test` is built using a client that makes use of the native
+Tendermint RPC client to interact with a Tendermint network running the
+`kvstore` application.
+
+If, however, you want to customize the load testing client for your own ABCI
+application, you can do so by implementing the `loadtest.ClientFactory` and
+`loadtest.Client` interfaces. An example of this is the provided Tendermint
+RPC-based client factory and client [here](./client.go#148).
+
+## Interactions
+At a high level, a client executes **interactions**, where a single interaction
+is made up of a series of requests. For the provided `kvstore` application, the
+two requests that make up an interaction are:
+
+1. Put a value into the `kvstore` by way of a `broadcast_tx_sync` request. This
+   request is directed at a random Tendermint node in the network.
+2. Retrieve the value from the `kvstore` for the original key and make sure that
+   the retrieved value is the same as the stored value. This request is also
+   directed at a (potentially different) random node in the Tendermint network.
+
+You can implement your own complex scenarios for your own application within an
+"interaction".
+
+## Custom Client Project Setup
+To create your own load testing tool for your environment, you will need to
+create your own equivalent of the `tm-load-test` command, but register your
+client during startup for use from the configuration file.
+
+```go
+package main
+
+import (
+    "github.com/tendermint/networks/pkg/loadtest"
+)
+
+func init() {
+    // Register your custom client factory here
+    loadtest.RegisterClientFactory("myclient", &MyCustomClientFactory{})
+}
+
+func main() {
+    // This will parse command line flags, configuration, etc. and actually
+    // execute the load testing framework in either master or slave mode,
+    // depending on the command line parameters supplied.
+    loadtest.Run()
+}
+```

--- a/pkg/loadtest/runners.go
+++ b/pkg/loadtest/runners.go
@@ -1,12 +1,71 @@
 package loadtest
 
 import (
+	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/sirupsen/logrus"
 	"github.com/tendermint/networks/pkg/loadtest/messages"
 )
+
+// Run must be executed from your `main` function in your Go code. This can be
+// used to fast-track the construction of your own load testing tool for your
+// Tendermint ABCI application.
+func Run() {
+	var (
+		isMaster   = flag.Bool("master", false, "start this process in MASTER mode")
+		isSlave    = flag.Bool("slave", false, "start this process in SLAVE mode")
+		configFile = flag.String("c", "load-test.toml", "the path to the configuration file for a load test")
+		isVerbose  = flag.Bool("v", false, "increase logging verbosity to DEBUG level")
+	)
+	flag.Usage = func() {
+		fmt.Println(`Tendermint load testing utility
+
+tm-load-test is a tool for distributed load testing on Tendermint networks,
+assuming that your Tendermint network currently runs the "kvstore" proxy app.
+
+Usage:
+  tm-load-test -c load-test.toml -master   # Run a master
+  tm-load-test -c load-test.toml -slave    # Run a slave
+
+Flags:`)
+		flag.PrintDefaults()
+		fmt.Println("")
+	}
+	flag.Parse()
+
+	if (!*isMaster && !*isSlave) || (*isMaster && *isSlave) {
+		fmt.Println("Either -master or -slave is expected on the command line to explicitly specify which mode to use.")
+		os.Exit(1)
+	}
+
+	if *isVerbose {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	logger := logrus.WithField("ctx", "main")
+
+	var err error
+
+	if *isMaster {
+		logger.Infoln("Starting in MASTER mode")
+		err = RunMaster(*configFile)
+	} else {
+		logger.Infoln("Starting in SLAVE mode")
+		err = RunSlave(*configFile)
+	}
+
+	if err != nil {
+		logger.WithError(err).Errorln("Load test execution failed")
+		if ltErr, ok := err.(*Error); ok {
+			os.Exit(int(ltErr.Code))
+		} else {
+			os.Exit(1)
+		}
+	}
+}
 
 // RunMaster will build and execute a master node for load testing and will
 // block until the testing is complete or fails.


### PR DESCRIPTION
The way in which one creates a custom Tendermint load testing client needs to be simplified, and this code makes that possible. This also improves the docs a bit for building the load testing tools, as well as adds some docs on how to build your own custom load testing client.