### PR TITLE
Fix hosts group in 001-reference deployment script

### DIFF
--- a/scripts/load-testing/networks/001-reference/deploy.yml
+++ b/scripts/load-testing/networks/001-reference/deploy.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: tik
+- hosts: tendermint
   become: yes
   vars:
     always_deploy_svc: no


### PR DESCRIPTION
The `hosts` entry here should have been `tendermint` instead of the old `tik` group.