### PR TITLE
Refactor Prometheus stats collection to simplify

### DIFF
--- a/pkg/loadtest/config.go
+++ b/pkg/loadtest/config.go
@@ -228,7 +228,7 @@ func (c *TestNetworkTargetConfig) Validate(i int) error {
 // specified Prometheus endpoints. The right format for `prometheus_urls`
 // parameter resembles the following:
 // id1=http://server1,id2=http://server2
-func (c *TestNetworkTargetConfig) GetPrometheusEndpoints() []*PrometheusEndpoint {
+func (c TestNetworkTargetConfig) GetPrometheusEndpoints() []*PrometheusEndpoint {
 	idURLs := strings.Split(c.PrometheusURLs, ",")
 	endpoints := make([]*PrometheusEndpoint, 0)
 	for _, idURL := range idURLs {

--- a/pkg/loadtest/master.go
+++ b/pkg/loadtest/master.go
@@ -61,7 +61,7 @@ func NewMaster(cfg *Config, probe Probe) (*actor.PID, *actor.RootContext, error)
 				RequestWaitMin:     time.Duration(cfg.Clients.RequestWaitMin),
 				RequestWaitMax:     time.Duration(cfg.Clients.RequestWaitMax),
 			}),
-			pstats:                 NewPrometheusStats(),
+			pstats:                 NewPrometheusStats(logging.NewLogrusLogger("prometheus")),
 			interactionCount:       make(map[string]int64),
 			expectedInteractions:   int64(cfg.Master.ExpectSlaves * cfg.Clients.Spawn * cfg.Clients.MaxInteractions),
 			lastProgressUpdate:     time.Now(),

--- a/pkg/loadtest/slave.go
+++ b/pkg/loadtest/slave.go
@@ -245,7 +245,7 @@ func (s *Slave) spawnClientStatsReceiver(clientParams ClientParams, expectedTota
 			}
 		}
 		// submit the overall stats for counting
-		finalStatsc <- overallStats
+		finalStatsc <- SummarizeCombinedStats(overallStats)
 	}()
 }
 


### PR DESCRIPTION
The Prometheus stats collection is refactored here into a `prometheusCollector` agent to make its operation more explicit.

Also, only the top 10 errors from each slave are sent through to the master to avoid hitting gRPC message size limits.