### PR TITLE
Add WebSockets-based Tendermint RPC client

### DIFF
--- a/examples/load-test.toml
+++ b/examples/load-test.toml
@@ -66,6 +66,10 @@ prometheus_poll_timeout = "1s"
 # interacting with remote Tendermint nodes' RPC endpoints.
 type = "tmrpc"
 
+# Configuration specific to this type of load testing client. The format for
+# this depends entirely on how the client wants to interpret these parameters.
+additional_config = ""
+
 # The number of clients to spawn per slave.
 spawn = 500
 

--- a/pkg/loadtest/client.go
+++ b/pkg/loadtest/client.go
@@ -23,6 +23,7 @@ type ClientParams struct {
 	RequestWaitMax     time.Duration // The maximum time to wait prior to executing a request.
 	RequestTimeout     time.Duration // The maximum time to allow for a request.
 	TotalClients       int64         // The total number of clients for which to initialize the load testing.
+	AdditionalParams   string        // The additional parameters provided through the load test configuration file.
 }
 
 // ClientFactory produces clients.

--- a/pkg/loadtest/client/kvstore.go
+++ b/pkg/loadtest/client/kvstore.go
@@ -1,0 +1,120 @@
+package client
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/tendermint/networks/pkg/loadtest"
+	"github.com/tendermint/networks/pkg/loadtest/messages"
+	rpclib "github.com/tendermint/tendermint/rpc/lib/client"
+)
+
+// KVStoreClientFactory produces KVStoreClient instances.
+type KVStoreClientFactory struct{}
+
+// KVStoreClient is a load testing client that interacts with a Tendermint
+// network via WebSockets interfaces.
+type KVStoreClient struct {
+	cfg       *KVStoreClientConfig
+	wsClients []*rpclib.WSClient
+
+	stats *messages.CombinedStats
+}
+
+// KVStoreClientConfig is to be parsed out of the `clients.additional_config`
+// field.
+type KVStoreClientConfig struct {
+	MaxConns int    `toml:"max_conns,omitempty"` // The maximum number of node connections. If not specified, we'll use the number of target nodes minus 1.
+	Endpoint string `toml:"endpoint,omitempty"`  // The WebSockets endpoint path (usually "/websocket").
+}
+
+var defaultKVStoreClientConfig = KVStoreClientConfig{
+	MaxConns: 1,
+	Endpoint: "/websocket",
+}
+
+// KVStoreClientFactory implements loadtest.ClientFactory
+var _ loadtest.ClientFactory = (*KVStoreClientFactory)(nil)
+
+// KVStoreClient implements loadtest.KVStoreClient
+var _ loadtest.Client = (*KVStoreClient)(nil)
+
+func init() {
+	loadtest.RegisterClientFactory("kvstore", &KVStoreClientFactory{})
+}
+
+// ParseKVStoreConfig will parse the given string assuming it's (1)
+// configuration for a `KVStoreClient`, and (2) that its contents are formatted
+// as the contents of an inline table in TOML format (but without the outermost
+// curly braces). On error, this just returns the default configuration.
+func ParseKVStoreConfig(s string) *KVStoreClientConfig {
+	cfg := &KVStoreClientConfig{}
+	// if we can't parse it, just ignore the error and return a default
+	// configuration
+	if _, err := toml.Decode("{"+s+"}", &cfg); err != nil {
+		return &defaultKVStoreClientConfig
+	}
+	if cfg.MaxConns < 1 {
+		cfg.MaxConns = defaultKVStoreClientConfig.MaxConns
+	}
+	if len(cfg.Endpoint) == 0 {
+		cfg.Endpoint = defaultKVStoreClientConfig.Endpoint
+	}
+	return cfg
+}
+
+//
+// KVStoreClientFactory
+//
+
+// NewStats creates a fresh new `CombinedStats` object for use in stats
+// tracking for this client type.
+func (cf *KVStoreClientFactory) NewStats(params loadtest.ClientParams) *messages.CombinedStats {
+	return nil
+}
+
+// NewClient instantiates a `KVStoreClient` that is connected to several
+// Tendermint network WebSockets endpoints.
+func (cf *KVStoreClientFactory) NewClient(params loadtest.ClientParams) loadtest.Client {
+	client := &KVStoreClient{
+		cfg:       ParseKVStoreConfig(params.AdditionalParams),
+		wsClients: make([]*rpclib.WSClient, 0),
+		stats:     cf.NewStats(params),
+	}
+	// shuffle the target nodes in the parameters
+	rand.Shuffle(len(params.TargetNodes), func(i, j int) {
+		params.TargetNodes[i], params.TargetNodes[j] = params.TargetNodes[j], params.TargetNodes[i]
+	})
+	// connect to the desired number of WebSocket endpoints
+	for i := 0; i < client.cfg.MaxConns && i < len(params.TargetNodes); i++ {
+		wsClient := rpclib.NewWSClient(
+			params.TargetNodes[i],
+			client.cfg.Endpoint,
+			rpclib.PingPeriod(1*time.Second),
+		)
+		// this will cause the WebSockets client to dial the Tendermint RPC
+		// endpoint and start the WebSockets read/write loop
+		if err := wsClient.Start(); err != nil {
+			panic(err)
+		}
+		client.wsClients = append(client.wsClients, wsClient)
+	}
+	return client
+}
+
+//
+// KVStoreClient
+//
+
+// Interact will attempt to put a value into the kvstore by way of one of its
+// WebSocket connections, and wait for it to be committed. After that it will
+// validate that the committed value was, indeed, the same as the one we put in.
+func (c *KVStoreClient) Interact() {
+
+}
+
+// GetStats will return the current stats object for this client.
+func (c *KVStoreClient) GetStats() *messages.CombinedStats {
+	return c.stats
+}

--- a/pkg/loadtest/config.go
+++ b/pkg/loadtest/config.go
@@ -71,15 +71,16 @@ type TestNetworkTargetConfig struct {
 
 // ClientConfig contains the configuration for clients being spawned on slaves.
 type ClientConfig struct {
-	Type               string            `toml:"type"`                // The type of client to spawn.
-	Spawn              int               `toml:"spawn"`               // The number of clients to spawn, per slave.
-	SpawnRate          float64           `toml:"spawn_rate"`          // The rate at which to spawn clients, per second, on each slave.
-	MaxInteractions    int               `toml:"max_interactions"`    // The maximum number of interactions emanating from each client.
-	MaxTestTime        ParseableDuration `toml:"max_test_time"`       // The maximum duration of the test, beyond which this client must be stopped.
-	RequestWaitMin     ParseableDuration `toml:"request_wait_min"`    // The minimum wait period before each request before sending another one.
-	RequestWaitMax     ParseableDuration `toml:"request_wait_max"`    // The maximum wait period before each request before sending another one.
-	RequestTimeout     ParseableDuration `toml:"request_timeout"`     // The maximum time allowed before considering a request to have timed out.
-	InteractionTimeout ParseableDuration `toml:"interaction_timeout"` // The maximum time allowed for an overall interaction.
+	Type               string            `toml:"type"`                        // The type of client to spawn.
+	AdditionalParams   string            `toml:"additional_params,omitempty"` // Optional additional parameters (client type-specific).
+	Spawn              int               `toml:"spawn"`                       // The number of clients to spawn, per slave.
+	SpawnRate          float64           `toml:"spawn_rate"`                  // The rate at which to spawn clients, per second, on each slave.
+	MaxInteractions    int               `toml:"max_interactions"`            // The maximum number of interactions emanating from each client.
+	MaxTestTime        ParseableDuration `toml:"max_test_time"`               // The maximum duration of the test, beyond which this client must be stopped.
+	RequestWaitMin     ParseableDuration `toml:"request_wait_min"`            // The minimum wait period before each request before sending another one.
+	RequestWaitMax     ParseableDuration `toml:"request_wait_max"`            // The maximum wait period before each request before sending another one.
+	RequestTimeout     ParseableDuration `toml:"request_timeout"`             // The maximum time allowed before considering a request to have timed out.
+	InteractionTimeout ParseableDuration `toml:"interaction_timeout"`         // The maximum time allowed for an overall interaction.
 }
 
 // ParseableDuration represents a time.Duration that implements

--- a/pkg/loadtest/slave.go
+++ b/pkg/loadtest/slave.go
@@ -173,6 +173,7 @@ func (s *Slave) doLoadTest(ctx actor.Context, slavePID *actor.PID) {
 		RequestWaitMax:     time.Duration(s.cfg.Clients.RequestWaitMax),
 		RequestTimeout:     time.Duration(s.cfg.Clients.RequestTimeout),
 		TotalClients:       0, // we set this to 0 because we have 0 clients initially
+		AdditionalParams:   s.cfg.Clients.AdditionalParams,
 	}
 	wg := &sync.WaitGroup{}
 	s.logger.Info("Starting client spawning", "desiredCount", s.cfg.Clients.Spawn)


### PR DESCRIPTION
We need our load testing to take place via the WebSockets RPC endpoint to minimize latency, maximize throughput and decrease communication failures during load testing. This is so that we can focus on the things we want to measure as opposed to measuring transient networking issues or the possibility that we can't open enough ports from a slave node.