### PR TITLE
Improve scripts' configurability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /.vscode/
 /build/
 /scripts/load-testing/venv/
+/scripts/load-testing/inventory/myhosts
 /scripts/load-testing/experiments/**/*-clients-*/
 /scripts/load-testing/experiments/**/collection.log
 *.pyc

--- a/scripts/load-testing/common/ansible/install-tm-svc.yml
+++ b/scripts/load-testing/common/ansible/install-tm-svc.yml
@@ -1,17 +1,17 @@
 ---
 - name: Ensure service group exists
   group:
-    name: tendermint
+    name: "{{ tm_user }}"
     state: present
 - name: Ensure service user exists
   user:
-    name: tendermint
-    group: tendermint
+    name: "{{ tm_user }}"
+    group: "{{ tm_user }}"
     home: /home/tendermint
     state: present
-- name: Copy service definition to nodes
-  copy:
-    src: config/tendermint.service
+- name: Deploy service definition to nodes
+  template:
+    src: templates/tendermint.service.jinja2
     dest: /etc/systemd/system/tendermint.service
 - name: Reload systemd services
   systemd:

--- a/scripts/load-testing/common/ansible/templates/tendermint.service.jinja2
+++ b/scripts/load-testing/common/ansible/templates/tendermint.service.jinja2
@@ -5,8 +5,8 @@ After=network-online.target
 
 [Service]
 Restart=on-failure
-User=tendermint
-Group=tendermint
+User={{ tm_user }}
+Group={{ tm_user }}
 PermissionsStartOnly=true
 ExecStart=/usr/bin/tendermint node
 KillSignal=SIGTERM

--- a/scripts/load-testing/networks/001-reference/Makefile
+++ b/scripts/load-testing/networks/001-reference/Makefile
@@ -4,9 +4,11 @@ FAST_MODE?=false
 GOPATH?=$(shell go env GOPATH)
 WITH_CLEVELDB?=false
 INSTALL_TENDERMINT_LOCALLY?=false
-TENDERMINT_SRC=$(GOPATH)/src/github.com/tendermint/tendermint
-TM_NETWORKS_SRC=$(GOPATH)/src/github.com/tendermint/networks
-TM_OUTAGE_SIM_SERVER_BIN=$(TM_NETWORKS_SRC)/build/tm-outage-sim-server
+TENDERMINT_SRC?=$(GOPATH)/src/github.com/tendermint/tendermint
+TM_NETWORKS_SRC?=$(GOPATH)/src/github.com/tendermint/networks
+TM_OUTAGE_SIM_SERVER_BIN?=$(TM_NETWORKS_SRC)/build/tm-outage-sim-server
+TM_USER?=tendermint
+TM_ALWAYS_DEPLOY?=no
 NETWORK_CONFIG_SCRIPT?=./scripts/001-default.sh
 CONFIG_SCRIPT?=$(NETWORK_CONFIG_SCRIPT)
 NETWORK_VALIDATORS?=4
@@ -35,6 +37,8 @@ deploy:
 	ansible-playbook -i $(INVENTORY) \
 		-e "{\"fast_mode\":${FAST_MODE}}" \
 		-e "{\"with_cleveldb\":${WITH_CLEVELDB}}" \
+		-e "{\"tm_user\": \"${TM_USER}\"}" \
+		-e "{\"always_deploy_svc\": ${TM_ALWAYS_DEPLOY}}" \
 		-e "{\"tm_outage_sim_server_bin\":\"${TM_OUTAGE_SIM_SERVER_BIN}\"}" \
 		deploy.yml
 	@echo "Checking if Tendermint nodes are up..."

--- a/scripts/load-testing/networks/001-reference/deploy.yml
+++ b/scripts/load-testing/networks/001-reference/deploy.yml
@@ -8,6 +8,7 @@
     node_exporter_url: "https://github.com/prometheus/node_exporter/releases/download/v0.17.0/node_exporter-0.17.0.linux-amd64.tar.gz"
     fast_mode: no
     with_cleveldb: no
+    tm_user: tendermint
   tasks:
     # If we need cleveldb support
     - name: Install cleveldb dependencies on target nodes, if necessary
@@ -74,8 +75,8 @@
     - name: Set Tendermint home permissions
       file:
         path: /home/tendermint/.tendermint
-        owner: tendermint
-        group: tendermint
+        owner: "{{ tm_user }}"
+        group: "{{ tm_user }}"
         recurse: yes
 
     # Start the Tendermint service


### PR DESCRIPTION
In certain cases, we need to configure the Tendermint user to have a different username, and we need to allow an environment variable to override whether or not to force the network deployment script to redeploy the Tendermint service.